### PR TITLE
Add automatic Paragon user token refresh

### DIFF
--- a/hooks/useParagon.js
+++ b/hooks/useParagon.js
@@ -5,7 +5,23 @@ if (typeof window !== "undefined") {
   window.paragon = paragon;
 }
 
-export default function useParagon(paragonUserToken) {
+function decodeJwt(token) {
+  try {
+    const base64Payload = token.split(".")[1];
+    const payload =
+      typeof window === "undefined"
+        ? Buffer.from(base64Payload, "base64").toString("utf8")
+        : atob(base64Payload);
+    return JSON.parse(payload);
+  } catch (e) {
+    return {};
+  }
+}
+
+const REFRESH_BUFFER_MS = 60 * 1000; // refresh one minute before token expiry
+
+export default function useParagon(initialToken) {
+  const [paragonUserToken, setParagonUserToken] = useState(initialToken);
   const [user, setUser] = useState(paragon.getUser());
   const [error, setError] = useState();
 
@@ -26,12 +42,13 @@ export default function useParagon(paragonUserToken) {
     };
   }, []);
 
+  // Authenticate with the current token
   useEffect(() => {
-    if (!error) {
+    if (!error && paragonUserToken) {
       paragon
         .authenticate(
           process.env.NEXT_PUBLIC_PARAGON_PROJECT_ID,
-          paragonUserToken
+          paragonUserToken,
         )
         .then(() => {
           const authedUser = paragon.getUser();
@@ -42,6 +59,29 @@ export default function useParagon(paragonUserToken) {
         .catch(setError);
     }
   }, [error, paragonUserToken]);
+
+  // Refresh the token before it expires
+  useEffect(() => {
+    if (!paragonUserToken || typeof window === "undefined") return;
+    const payload = decodeJwt(paragonUserToken);
+    if (!payload.exp) return;
+
+    async function refresh() {
+      try {
+        const resp = await fetch("/api/paragon-token");
+        if (resp.ok) {
+          const data = await resp.json();
+          setParagonUserToken(data.paragonUserToken);
+        }
+      } catch (e) {
+        console.error("Failed to refresh Paragon token", e);
+      }
+    }
+
+    const refreshTime = payload.exp * 1000 - Date.now() - REFRESH_BUFFER_MS;
+    const timer = setTimeout(refresh, Math.max(refreshTime, 0));
+    return () => clearTimeout(timer);
+  }, [paragonUserToken]);
 
   return {
     paragon,

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -1,0 +1,25 @@
+const jsonwebtoken = require("jsonwebtoken");
+
+function generateParagonUserToken(userId) {
+  const createdAt = Math.floor(Date.now() / 1000);
+  return jsonwebtoken.sign(
+    {
+      sub: userId,
+      iat: createdAt,
+      exp: createdAt + 60 * 60,
+    },
+    process.env.PARAGON_SIGNING_KEY,
+    { algorithm: "RS256" },
+  );
+}
+
+function getLoggedInUser() {
+  const user = {
+    id: "1f45e694-977a-474c-b630-da5c7839ad94",
+    name: "Sean Victory",
+  };
+  user.paragonUserToken = generateParagonUserToken(user.id);
+  return user;
+}
+
+module.exports = { generateParagonUserToken, getLoggedInUser };

--- a/pages/api/paragon-token.js
+++ b/pages/api/paragon-token.js
@@ -1,0 +1,6 @@
+import { getLoggedInUser } from "../../lib/auth";
+
+export default function handler(req, res) {
+  const user = getLoggedInUser();
+  res.status(200).json({ paragonUserToken: user.paragonUserToken });
+}

--- a/server.js
+++ b/server.js
@@ -1,37 +1,14 @@
 const { createServer } = require("http");
 const { parse } = require("url");
 const next = require("next");
-const jsonwebtoken = require("jsonwebtoken");
+const { getLoggedInUser } = require("./lib/auth");
 
 const dev = process.env.NODE_ENV !== "production";
 const app = next({ dev });
 const handle = app.getRequestHandler();
 
-// Generate a Paragon User Token with a JWT library, using a user ID and the
-// Paragon Signing Key (stored in environment variables).
-function generateParagonUserToken(userId) {
-  const createdAt = Math.floor(Date.now() / 1000);
-  return jsonwebtoken.sign(
-    {
-      sub: userId,
-      iat: createdAt,
-      exp: createdAt + 60 * 60,
-    },
-    process.env.PARAGON_SIGNING_KEY,
-    { algorithm: "RS256" }
-  );
-}
-
-// This function might use a session identifier to find a logged-in user and
-// return their user details. Here, we use a static value for the demo.
-function getLoggedInUser() {
-  const user = {
-    id: "1f45e694-977a-474c-b630-da5c7839ad94",
-    name: "Sean Victory",
-  };
-  user.paragonUserToken = generateParagonUserToken(user.id);
-  return user;
-}
+// generateParagonUserToken and getLoggedInUser are provided by lib/auth and
+// used to mock an authenticated user for the demo.
 
 const port = process.env.PORT ?? 3000;
 app.prepare().then(() => {


### PR DESCRIPTION
## Summary
- share auth utilities in `lib/auth.js`
- update custom server to use shared auth helpers
- expose `/api/paragon-token` API route for refreshing JWTs
- refresh the Paragon user token in `useParagon` when nearing expiry

## Testing
- `npm run build` *(fails: `next` not found)*